### PR TITLE
fix checkout of gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ target/
 .idea
 
 playground
+
+pages-clone/

--- a/deploy_pages.sh
+++ b/deploy_pages.sh
@@ -16,7 +16,7 @@ git clone "$REPO" "$TEMP_DIR"
 cd "$TEMP_DIR"
 
 # Remove old contents, copy new contents into place, commit and push everything
-git checkout gh-pages
+git checkout -t origin/gh-pages
 rm -rf *
 cp -R ../docs/_build/html/* .
 

--- a/deploy_pages.sh
+++ b/deploy_pages.sh
@@ -20,6 +20,8 @@ git checkout gh-pages
 rm -rf *
 cp -R ../docs/_build/html/* .
 
+touch .nojekyll
+
 git add .
 git add -u
 git commit -m "Update website"

--- a/deploy_pages.sh
+++ b/deploy_pages.sh
@@ -16,7 +16,7 @@ git clone "$REPO" "$TEMP_DIR"
 cd "$TEMP_DIR"
 
 # Remove old contents, copy new contents into place, commit and push everything
-git checkout -b gh-pages
+git checkout gh-pages
 rm -rf *
 cp -R ../docs/_build/html/* .
 


### PR DESCRIPTION
I got an error after the gh-pages branch differed from the master branch. So i removed the -b on the checkout so it pulls the remote gh-pages branch. Furthermore i made the script creating a ``.nojekyll`` file, which is needed that github knows its not a jekyll based page.

@aahlenst Can you verify that this works, or did i get something wrong?