### PR TITLE
Streamline dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Install the latest development version:
 pip install git+https://github.com/ynop/pingu.git
 ```
 
-
 ## Example
 Example for loading a corpus and using the FramedSignalGrabber to retrieve the audio signal in frames.
 
@@ -27,3 +26,45 @@ Example for loading a corpus and using the FramedSignalGrabber to retrieve the a
    -0.01263466, -0.01232948], dtype=float32), array([ 0.,  0.,  1.,  0.], dtype=float32))
 ...
 ```
+
+## Development
+
+### Prerequisites
+
+* [A supported version of Python 3](https://docs.python.org/devguide/index.html#status-of-python-branches)
+
+It's recommended to use a virtual environment when developing Pingu. To create one, execute the following command in the project's root directory:
+
+```
+python -m venv .
+```
+
+To install Pingu and all it's dependencies, execute:
+
+```
+pip install -e .
+```
+
+### Running the test suite
+
+```
+pip install -e .[test]
+python setup.py test
+```
+
+### Editing the Documentation
+
+The documentation is written in [reStructuredText](http://docutils.sourceforge.net/rst.html) and transformed into various output formats with the help of [Sphinx](http://www.sphinx-doc.org/).
+
+* [Syntax reference reStructuredText](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
+* [Sphinx-specific additions to reStructuredText](http://www.sphinx-doc.org/en/stable/markup/index.html)
+
+To generate the documentation, execute:
+
+```
+pip install -e .[docs]
+cd docs
+make html
+```
+
+The generated files are written to `docs/_build/html`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-scipy
-librosa
-h5py

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
-from setuptools import setup
 from setuptools import find_packages
-
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+from setuptools import setup
 
 setup(name='pingu',
       version='0.1',
@@ -19,12 +16,17 @@ setup(name='pingu',
       keywords='',
       license='MIT',
       packages=find_packages(),
-      install_requires=required,
+      install_requires=[
+          'numpy==1.13.3',
+          'scipy==1.0.0',
+          'librosa==0.5.1',
+          'h5py==2.7.1'
+      ],
       include_package_data=True,
       zip_safe=False,
       test_suite='nose.collector',
       extras_require={
-          'test': ['nose'],
+          'test': ['nose==1.3.7'],
           'docs': ['Sphinx==1.6.5', 'sphinx-rtd-theme==0.2.5b1']
       },
       entry_points={


### PR DESCRIPTION
I've removed the separate `requirements.txt` and moved everything into `setup.py`. Otherwise some dependencies could be installed using `pip install -r requirements.txt` and some only through e.g. `pip install -e .[docs]`. I've also specified the exact version numbers for each dependency so that we get a reproducible build.