### PR TITLE
use a 'audio_type' as idx for all label-lists

### DIFF
--- a/pingu/corpus/io/musan.py
+++ b/pingu/corpus/io/musan.py
@@ -60,7 +60,7 @@ class MusanLoader(base.CorpusLoader):
 
                         corpus.new_file(file_path, file_idx=file_idx, copy_file=False)
                         corpus.new_utterance(utterance_idx, file_idx, issuer_idx)
-                        corpus.new_label_list(utterance_idx, idx=type_name, labels=[assets.Label(type_name)])
+                        corpus.new_label_list(utterance_idx, idx='audio_type', labels=[assets.Label(type_name)])
 
         return corpus
 

--- a/tests/corpus/io/test_musan.py
+++ b/tests/corpus/io/test_musan.py
@@ -92,20 +92,18 @@ class MusanCorpusLoaderTest(unittest.TestCase):
     def test_load_label_lists(self):
         ds = self.loader.load(self.test_path)
 
-        self.assertIn('music', ds.label_lists.keys())
-        self.assertIn('noise', ds.label_lists.keys())
+        self.assertIn('audio_type', ds.label_lists.keys())
 
-        self.assertEqual(1, len(ds.label_lists['music'].keys()))
-        self.assertEqual(2, len(ds.label_lists['noise'].keys()))
+        self.assertEqual(5, len(ds.label_lists['audio_type'].keys()))
 
-        self.assertIn('music-fma-0000', ds.label_lists['music'].keys())
-        self.assertIn('noise-free-sound-0000', ds.label_lists['noise'].keys())
-        self.assertIn('noise-free-sound-0001', ds.label_lists['noise'].keys())
+        self.assertIn('music-fma-0000', ds.label_lists['audio_type'].keys())
+        self.assertIn('noise-free-sound-0000', ds.label_lists['audio_type'].keys())
+        self.assertIn('noise-free-sound-0001', ds.label_lists['audio_type'].keys())
 
-        self.assertEqual(1, len(ds.label_lists['music']['music-fma-0000'].labels))
-        self.assertEqual(1, len(ds.label_lists['noise']['noise-free-sound-0000'].labels))
-        self.assertEqual(1, len(ds.label_lists['noise']['noise-free-sound-0001'].labels))
+        self.assertEqual(1, len(ds.label_lists['audio_type']['music-fma-0000'].labels))
+        self.assertEqual(1, len(ds.label_lists['audio_type']['noise-free-sound-0000'].labels))
+        self.assertEqual(1, len(ds.label_lists['audio_type']['noise-free-sound-0001'].labels))
 
-        self.assertEqual('music', ds.label_lists['music']['music-fma-0000'].labels[0].value)
-        self.assertEqual('noise', ds.label_lists['noise']['noise-free-sound-0000'].labels[0].value)
-        self.assertEqual('noise', ds.label_lists['noise']['noise-free-sound-0001'].labels[0].value)
+        self.assertEqual('music', ds.label_lists['audio_type']['music-fma-0000'].labels[0].value)
+        self.assertEqual('noise', ds.label_lists['audio_type']['noise-free-sound-0000'].labels[0].value)
+        self.assertEqual('noise', ds.label_lists['audio_type']['noise-free-sound-0001'].labels[0].value)


### PR DESCRIPTION
Since all the labels basically describe the audio-type, i think it is better idx for the label-lists. 
So when i want to train a audio type classifier, i can grab the audio-type label-lists and get the labels i need.