### PR TITLE
Return list instead of None when files are missing

### DIFF
--- a/pingu/corpus/io/base.py
+++ b/pingu/corpus/io/base.py
@@ -26,7 +26,7 @@ class CorpusReader(metaclass=abc.ABCMeta):
         # Check for missing files
         missing_files = self._check_for_missing_files(path)
 
-        if missing_files is not None:
+        if len(missing_files) > 0:
             raise IOError('Invalid data set of type {}: files {} not found at {}'.format(
                 self.type(), ' '.join(missing_files), path))
 
@@ -65,10 +65,17 @@ class CorpusReader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def _check_for_missing_files(self, path):
         """
-        Return a list of necessary files for the current type of data set that are missing in the given folder.
-        None if path seems valid.
+        Tests whether all required files (like annotations) to read the corpus successfully are present. If files are
+        missing, a list with the paths of the missing files is returned. All paths are relative to `path`. If no files
+        are missing, an empty list is returned.
+
+        Args:
+            path (str): Path to the root directory of the data set
+
+        Returns:
+            list: Paths of all the missing files, relative to the path of the root directory of the data set.
         """
-        return None
+        return []
 
 
 class CorpusWriter(metaclass=abc.ABCMeta):

--- a/pingu/corpus/io/broadcast.py
+++ b/pingu/corpus/io/broadcast.py
@@ -32,7 +32,7 @@ class BroadcastReader(base.CorpusReader):
             if not os.path.isfile(file_path):
                 missing_files.append(file_name)
 
-        return missing_files or None
+        return missing_files
 
     def _load(self, path):
         corpus = pingu.Corpus(path=path)

--- a/pingu/corpus/io/default.py
+++ b/pingu/corpus/io/default.py
@@ -33,7 +33,7 @@ class DefaultReader(base.CorpusReader):
             if not os.path.isfile(file_path):
                 missing_files.append(file_name)
 
-        return missing_files or None
+        return missing_files
 
     def _load(self, path):
         corpus = pingu.Corpus(path=path)

--- a/pingu/corpus/io/kaldi.py
+++ b/pingu/corpus/io/kaldi.py
@@ -45,7 +45,7 @@ class KaldiReader(base.CorpusReader):
             if not os.path.isfile(file_path):
                 missing_files.append(file_name)
 
-        return missing_files or None
+        return missing_files
 
     def _load(self, path):
         corpus = pingu.Corpus(path=path)

--- a/pingu/corpus/io/musan.py
+++ b/pingu/corpus/io/musan.py
@@ -32,7 +32,7 @@ class MusanReader(base.CorpusReader):
     def _check_for_missing_files(self, path):
         # Some annotation files are missing anyway in the original data set
         # (e.g. speech/us-gov/ANNOTATIONS). What's left would be checking for missing directories.
-        pass
+        return []
 
     def _load(self, path):
         create_or_get_issuer = {


### PR DESCRIPTION
Returning different types depending on the outcome only confuses the IDE and makes the code more complicated.